### PR TITLE
fix: throw on non mocked method on class too

### DIFF
--- a/src/lib/proxy-class.test.ts
+++ b/src/lib/proxy-class.test.ts
@@ -42,4 +42,17 @@ describe('proxy class', () => {
         expect((proxy as any).method5).toBeUndefined(); // unknown method should not be mocked
         expect((proxy as any).method6).toBeUndefined(); // unknown method should not be mocked
     });
+
+    it('should throw error on methods whose implementation is not mocked explicitly', async () => {
+        const clazz = TestClass;
+        const proxy = createClassProxy(clazz);
+
+        expect(() => {
+            proxy.method1();
+        }).toThrowError('Method method1 is not mocked');
+
+        expect(() => {
+            (proxy as any)[Symbol('foo')]();
+        }).toThrowError('Method Symbol(foo) is not mocked');
+    });
 });

--- a/src/lib/proxy-class.ts
+++ b/src/lib/proxy-class.ts
@@ -10,7 +10,9 @@ export const createClassProxy = <T>(clazz: Class<T>): Mock<T> => {
             }
 
             if (functions.has(property as string)) {
-                target[property] = jest.fn();
+                target[property] = jest.fn().mockImplementation(() => {
+                    throw new Error(`Method ${String(property)} is not mocked`);
+                });
             }
 
             return target[property];


### PR DESCRIPTION
This PR adds the same feature as https://github.com/dariosn85/ts-jest-mocker/pull/4 but when mocking a class.